### PR TITLE
Support OpenIddict 7.0 client-assertion audience via discovery

### DIFF
--- a/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
+++ b/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -61,23 +62,37 @@ public sealed class ClientCredentials
         HttpClient httpClient = null)
     {
         var disposeHttpClient = httpClient == null;
-        var keyPairPtr = Marshal.SecureStringToGlobalAllocUnicode(KeyPairData);
-        
+        httpClient ??= new HttpClient();
+
         try
         {
-            httpClient ??= new HttpClient();
+            // Resolve the assertion format (a network call to the discovery endpoint) before pinning
+            // the private key in unmanaged memory, and unpin it immediately after reading it, so the
+            // plaintext key is exposed for as short a time as possible.
             var (audience, tokenType) = await ResolveAssertionFormat(httpClient).ConfigureAwait(false);
-            var keyPair = Internal.PrivateKey.ReadString(Marshal.PtrToStringUni(keyPairPtr));
+            var rsaParameters = ReadRsaParameters();
+
             return await httpClient.GetClientAccessToken(
-                    _tokenUrl, Id, keyPair.ToRSAParameters(), scopes, audience, tokenType)
+                    _tokenUrl, Id, rsaParameters, scopes, audience, tokenType)
                 .ConfigureAwait(false);
         }
         finally
         {
-            Marshal.ZeroFreeGlobalAllocUnicode(keyPairPtr);
             if (disposeHttpClient)
-                httpClient?.Dispose();
+                httpClient.Dispose();
+        }
+    }
 
+    private RSAParameters ReadRsaParameters()
+    {
+        var keyPairPtr = Marshal.SecureStringToGlobalAllocUnicode(KeyPairData);
+        try
+        {
+            return Internal.PrivateKey.ReadString(Marshal.PtrToStringUni(keyPairPtr)).ToRSAParameters();
+        }
+        finally
+        {
+            Marshal.ZeroFreeGlobalAllocUnicode(keyPairPtr);
         }
     }
 

--- a/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
+++ b/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
@@ -122,13 +122,24 @@ public sealed class ClientCredentials
                 "Could not read the identity provider's discovery document.", ex);
         }
 
-        var usesIssuerAudience =
+        var advertisesIssuerAudience =
             configuration.AdditionalData.TryGetValue(ClientAssertionAudienceMetadata, out var value)
-            && string.Equals(value?.ToString(), ClientAssertionAudienceIssuer, StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrEmpty(configuration.Issuer);
+            && string.Equals(value?.ToString(), ClientAssertionAudienceIssuer, StringComparison.OrdinalIgnoreCase);
 
-        return usesIssuerAudience
-            ? (configuration.Issuer, ClientAuthenticationJwtType)
-            : (_tokenUrl.AbsoluteUri, null);
+        if (advertisesIssuerAudience)
+        {
+            // The server explicitly requires the issuer as the audience, so a discovery document
+            // that advertises this but omits the issuer is invalid and must fail rather than
+            // downgrade to a legacy assertion the server would reject.
+            if (string.IsNullOrEmpty(configuration.Issuer))
+                throw new AccessTokenException(
+                    "The identity provider requires the issuer as the client-assertion audience, " +
+                    "but its discovery document does not contain an issuer.");
+
+            return (configuration.Issuer, ClientAuthenticationJwtType);
+        }
+
+        // Older servers don't advertise the flag and expect the token endpoint as the audience.
+        return (_tokenUrl.AbsoluteUri, null);
     }
 }

--- a/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
+++ b/src/Eryph.IdentityModel.Clients/ClientCredentials.cs
@@ -5,13 +5,22 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Eryph.IdentityModel.Clients;
 
 [PublicAPI]
 public sealed class ClientCredentials
 {
+    // Custom OpenID Connect discovery metadata entry advertised by eryph servers running
+    // OpenIddict 7.0 and higher. When present (value "issuer") the server expects the issuer
+    // as the client-assertion audience and the "client-authentication+jwt" token type.
+    private const string ClientAssertionAudienceMetadata = "eryph_client_assertion_audience";
+    private const string ClientAssertionAudienceIssuer = "issuer";
+    private const string ClientAuthenticationJwtType = "client-authentication+jwt";
+
     private readonly Uri _tokenUrl;
+    private readonly Uri _metadataUrl;
 
     public ClientCredentials(string id,
         SecureString keyPairData,
@@ -25,6 +34,12 @@ public sealed class ClientCredentials
         var uriBuilder = new UriBuilder(IdentityProvider);
         uriBuilder.Path += uriBuilder.Path.EndsWith("/") ? "connect/token" : "/connect/token";
         _tokenUrl = uriBuilder.Uri;
+
+        var metadataBuilder = new UriBuilder(IdentityProvider);
+        metadataBuilder.Path += metadataBuilder.Path.EndsWith("/")
+            ? ".well-known/openid-configuration"
+            : "/.well-known/openid-configuration";
+        _metadataUrl = metadataBuilder.Uri;
     }
 
     public string Id { get; }
@@ -51,9 +66,10 @@ public sealed class ClientCredentials
         try
         {
             httpClient ??= new HttpClient();
+            var (audience, tokenType) = await ResolveAssertionFormat(httpClient).ConfigureAwait(false);
             var keyPair = Internal.PrivateKey.ReadString(Marshal.PtrToStringUni(keyPairPtr));
             return await httpClient.GetClientAccessToken(
-                    _tokenUrl, Id, keyPair.ToRSAParameters(), scopes)
+                    _tokenUrl, Id, keyPair.ToRSAParameters(), scopes, audience, tokenType)
                 .ConfigureAwait(false);
         }
         finally
@@ -61,7 +77,43 @@ public sealed class ClientCredentials
             Marshal.ZeroFreeGlobalAllocUnicode(keyPairPtr);
             if (disposeHttpClient)
                 httpClient?.Dispose();
-            
+
         }
+    }
+
+    /// <summary>
+    /// Detects the expected client-assertion format from the server's OpenID Connect discovery
+    /// document. Newer eryph servers (OpenIddict 7.0+) advertise <c>eryph_client_assertion_audience
+    /// = issuer</c>, which requires the issuer as the audience and the <c>client-authentication+jwt</c>
+    /// token type; older servers expect the token endpoint as the audience.
+    /// </summary>
+    /// <remarks>
+    /// Every eryph identity server serves the discovery document, so a failure to read it is a real
+    /// error and is surfaced rather than silently downgrading to a format the server would reject.
+    /// </remarks>
+    private async Task<(string Audience, string TokenType)> ResolveAssertionFormat(HttpClient httpClient)
+    {
+        // Read the discovery document directly and parse it without fetching the server's signing
+        // keys (jwks_uri): the client signs assertions with its own key.
+        OpenIdConnectConfiguration configuration;
+        try
+        {
+            var json = await httpClient.GetStringAsync(_metadataUrl).ConfigureAwait(false);
+            configuration = OpenIdConnectConfiguration.Create(json);
+        }
+        catch (Exception ex)
+        {
+            throw new AccessTokenException(
+                "Could not read the identity provider's discovery document.", ex);
+        }
+
+        var usesIssuerAudience =
+            configuration.AdditionalData.TryGetValue(ClientAssertionAudienceMetadata, out var value)
+            && string.Equals(value?.ToString(), ClientAssertionAudienceIssuer, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(configuration.Issuer);
+
+        return usesIssuerAudience
+            ? (configuration.Issuer, ClientAuthenticationJwtType)
+            : (_tokenUrl.AbsoluteUri, null);
     }
 }

--- a/src/Eryph.IdentityModel.Clients/Eryph.IdentityModel.Clients.csproj
+++ b/src/Eryph.IdentityModel.Clients/Eryph.IdentityModel.Clients.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>

--- a/src/Eryph.IdentityModel/Clients/HttpClientRequestExtensions.cs
+++ b/src/Eryph.IdentityModel/Clients/HttpClientRequestExtensions.cs
@@ -27,13 +27,18 @@ public static class HttpClientExtensions
         Uri tokenEndpointUrl,
         string clientName,
         RSAParameters rsaParameters,
-        IReadOnlyList<string> scopes = null)
+        IReadOnlyList<string> scopes = null,
+        string audience = null,
+        string tokenType = null)
     {
         if (!tokenEndpointUrl.IsAbsoluteUri)
             throw new AccessTokenException("The token endpoint URL is not an absolute URL.");
 
-        var audience = tokenEndpointUrl.AbsoluteUri;
-        var jwt = CreateClientAssertionJwt(audience, clientName, rsaParameters);
+        // The audience defaults to the token endpoint (the behaviour expected by eryph servers
+        // before OpenIddict 7.0). Callers that detected a newer server pass the issuer as the
+        // audience together with the "client-authentication+jwt" token type.
+        var jwt = CreateClientAssertionJwt(
+            audience ?? tokenEndpointUrl.AbsoluteUri, tokenType, clientName, rsaParameters);
 
         var properties = new Dictionary<string, string>
         {
@@ -42,7 +47,7 @@ public static class HttpClientExtensions
             ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             ["client_assertion"] = jwt
         };
-        
+
         if (scopes is { Count: > 0 })
             properties.Add("scope", string.Join(" ", scopes));
 
@@ -108,14 +113,15 @@ public static class HttpClientExtensions
         HttpStatusCode statusCode) =>
         new($"Could not retrieve an access token. The server responded with {statusCode}.");
 
-    private static string CreateClientAssertionJwt(string audience, string clientName, RSAParameters rsaParameters)
+    private static string CreateClientAssertionJwt(
+        string audience, string tokenType, string clientName, RSAParameters rsaParameters)
     {
         // Set exp to 5 minutes
         var tokenHandler = new JwtSecurityTokenHandler { TokenLifetimeInMinutes = 5 };
         var securityToken = tokenHandler.CreateJwtSecurityToken(
             // iss must be the client_id of our application
             clientName,
-            // aud must be the identity provider (token endpoint)
+            // aud must be the identity provider: the issuer for newer servers, the token endpoint for older ones
             audience,
             // sub must be the client_id of our application
             subject: new ClaimsIdentity(
@@ -127,6 +133,11 @@ public static class HttpClientExtensions
             signingCredentials: new SigningCredentials(new RsaSecurityKey(rsaParameters), "RS256")
         );
 
+        // Newer eryph servers (OpenIddict 7.0+) require the standardized client-authentication+jwt
+        // token type. Older servers don't inspect the "typ" header, so it is only set when needed.
+        if (!string.IsNullOrEmpty(tokenType))
+            securityToken.Header["typ"] = tokenType;
+
         return tokenHandler.WriteToken(securityToken);
     }
 
@@ -135,7 +146,7 @@ public static class HttpClientExtensions
         [JsonRequired] public string AccessToken { get; set; }
 
         public int? ExpiresIn { get; set; }
-        
+
         public string Scope { get; set; }
     }
 

--- a/src/Eryph.IdentityModel/Clients/HttpClientRequestExtensions.cs
+++ b/src/Eryph.IdentityModel/Clients/HttpClientRequestExtensions.cs
@@ -22,14 +22,23 @@ public static class HttpClientExtensions
             PropertyNameCaseInsensitive = true,
         });
 
+    public static Task<AccessTokenResponse> GetClientAccessToken(
+        this HttpClient httpClient,
+        Uri tokenEndpointUrl,
+        string clientName,
+        RSAParameters rsaParameters,
+        IReadOnlyList<string> scopes = null)
+        => httpClient.GetClientAccessToken(
+            tokenEndpointUrl, clientName, rsaParameters, scopes, audience: null, tokenType: null);
+
     public static async Task<AccessTokenResponse> GetClientAccessToken(
         this HttpClient httpClient,
         Uri tokenEndpointUrl,
         string clientName,
         RSAParameters rsaParameters,
-        IReadOnlyList<string> scopes = null,
-        string audience = null,
-        string tokenType = null)
+        IReadOnlyList<string> scopes,
+        string audience,
+        string tokenType)
     {
         if (!tokenEndpointUrl.IsAbsoluteUri)
             throw new AccessTokenException("The token endpoint URL is not an absolute URL.");

--- a/test/Eryph.IdentityModel.Clients.Tests/ClientCredentialsTests.cs
+++ b/test/Eryph.IdentityModel.Clients.Tests/ClientCredentialsTests.cs
@@ -63,6 +63,20 @@ public class ClientCredentialsTests
     }
 
     [Fact]
+    public async Task GetAccessToken_IssuerAudienceAdvertisedButIssuerMissing_ThrowsAndDoesNotRequestToken()
+    {
+        // The server requires the issuer as the audience but the discovery document omits it:
+        // invalid metadata must fail rather than downgrade to a legacy assertion.
+        var handler = new FakeIdentityHandler(advertiseIssuerAudience: true) { IncludeIssuer = false };
+        using var httpClient = new HttpClient(handler);
+
+        var act = async () => await CreateCredentials().GetAccessToken(httpClient);
+
+        await act.Should().ThrowAsync<AccessTokenException>();
+        handler.TokenRequested.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetAccessToken_DiscoveryFailure_ThrowsAndDoesNotRequestToken()
     {
         var handler = new FakeIdentityHandler(advertiseIssuerAudience: true)
@@ -88,6 +102,8 @@ public class ClientCredentialsTests
 
         public HttpStatusCode DiscoveryStatus { get; set; } = HttpStatusCode.OK;
 
+        public bool IncludeIssuer { get; set; } = true;
+
         public bool TokenRequested { get; private set; }
 
         public string ClientAssertion { get; private set; }
@@ -104,9 +120,11 @@ public class ClientCredentialsTests
                     ? ", \"eryph_client_assertion_audience\": \"issuer\""
                     : "";
 
+                var issuerPart = IncludeIssuer ? $"\"issuer\": \"{Issuer}\", " : "";
                 var metadata =
                     "{" +
-                    $"\"issuer\": \"{Issuer}\", \"token_endpoint\": \"{TokenEndpoint}\"" +
+                    issuerPart +
+                    $"\"token_endpoint\": \"{TokenEndpoint}\"" +
                     flag +
                     "}";
 

--- a/test/Eryph.IdentityModel.Clients.Tests/ClientCredentialsTests.cs
+++ b/test/Eryph.IdentityModel.Clients.Tests/ClientCredentialsTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Eryph.IdentityModel.Clients;
+using FluentAssertions;
+using Xunit;
+
+namespace Eryph.IdentityModel.Clients.Tests;
+
+public class ClientCredentialsTests
+{
+    private const string IdentityProvider = "https://identity.test/identity";
+    private const string Issuer = "https://identity.test/identity";
+    private const string TokenEndpoint = "https://identity.test/identity/connect/token";
+
+    private static SecureString ToSecureString(string value)
+    {
+        var secure = new SecureString();
+        foreach (var c in value)
+            secure.AppendChar(c);
+        secure.MakeReadOnly();
+        return secure;
+    }
+
+    private static ClientCredentials CreateCredentials() =>
+        new("test-client", ToSecureString(TestData.PrivateKeyFileString), new Uri(IdentityProvider), "default");
+
+    [Fact]
+    public async Task GetAccessToken_NewServer_UsesIssuerAudienceAndJwtType()
+    {
+        var handler = new FakeIdentityHandler(advertiseIssuerAudience: true);
+        using var httpClient = new HttpClient(handler);
+
+        var token = await CreateCredentials().GetAccessToken(["compute_api"], httpClient);
+
+        token.AccessToken.Should().Be("token");
+
+        var assertion = new JwtSecurityTokenHandler().ReadJwtToken(handler.ClientAssertion);
+        assertion.Audiences.Should().ContainSingle().Which.Should().Be(Issuer);
+        assertion.Header["typ"].Should().Be("client-authentication+jwt");
+        assertion.Issuer.Should().Be("test-client");
+        assertion.Subject.Should().Be("test-client");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_LegacyServer_UsesTokenEndpointAudience()
+    {
+        var handler = new FakeIdentityHandler(advertiseIssuerAudience: false);
+        using var httpClient = new HttpClient(handler);
+
+        var token = await CreateCredentials().GetAccessToken(httpClient);
+
+        token.AccessToken.Should().Be("token");
+
+        var assertion = new JwtSecurityTokenHandler().ReadJwtToken(handler.ClientAssertion);
+        assertion.Audiences.Should().ContainSingle().Which.Should().Be(TokenEndpoint);
+        assertion.Header["typ"].Should().Be("JWT");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_DiscoveryFailure_ThrowsAndDoesNotRequestToken()
+    {
+        var handler = new FakeIdentityHandler(advertiseIssuerAudience: true)
+        {
+            DiscoveryStatus = HttpStatusCode.InternalServerError,
+        };
+        using var httpClient = new HttpClient(handler);
+
+        var act = async () => await CreateCredentials().GetAccessToken(httpClient);
+
+        await act.Should().ThrowAsync<AccessTokenException>();
+        handler.TokenRequested.Should().BeFalse();
+    }
+
+    private sealed class FakeIdentityHandler : HttpMessageHandler
+    {
+        private readonly bool _advertiseIssuerAudience;
+
+        public FakeIdentityHandler(bool advertiseIssuerAudience)
+        {
+            _advertiseIssuerAudience = advertiseIssuerAudience;
+        }
+
+        public HttpStatusCode DiscoveryStatus { get; set; } = HttpStatusCode.OK;
+
+        public bool TokenRequested { get; private set; }
+
+        public string ClientAssertion { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri.AbsolutePath.EndsWith("/.well-known/openid-configuration"))
+            {
+                if (DiscoveryStatus != HttpStatusCode.OK)
+                    return new HttpResponseMessage(DiscoveryStatus);
+
+                var flag = _advertiseIssuerAudience
+                    ? ", \"eryph_client_assertion_audience\": \"issuer\""
+                    : "";
+
+                var metadata =
+                    "{" +
+                    $"\"issuer\": \"{Issuer}\", \"token_endpoint\": \"{TokenEndpoint}\"" +
+                    flag +
+                    "}";
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(metadata) };
+            }
+
+            TokenRequested = true;
+            var body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ClientAssertion = HttpUtility.ParseQueryString(body)["client_assertion"];
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"token\"}"),
+            };
+        }
+    }
+}

--- a/test/Eryph.IdentityModel.Tests/HttpClientExtensionsTests.cs
+++ b/test/Eryph.IdentityModel.Tests/HttpClientExtensionsTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Eryph.IdentityModel.Clients;
 using FluentAssertions;
 using FluentAssertions.Extensions;
@@ -16,7 +18,10 @@ namespace Eryph.IdentityModel.Tests;
 
 public class HttpClientExtensionsTests
 {
-    private readonly Uri _tokenUrl = new("https://identity.test/identity/connect/token");
+    private const string Issuer = "https://identity.test/identity";
+    private const string TokenEndpoint = "https://identity.test/identity/connect/token";
+
+    private readonly Uri _tokenUrl = new(TokenEndpoint);
     private readonly Mock<HttpMessageHandler> _messageHandlerMock = new();
     private readonly RSAParameters _rsaParameters;
 
@@ -110,6 +115,51 @@ public class HttpClientExtensionsTests
 
         await act.Should().ThrowAsync<AccessTokenException>()
             .WithMessage("Could not retrieve an access token. The server responded with InternalServerError.");
+    }
+
+    [Fact]
+    public async Task GetClientAccessToken_WithIssuerAudienceAndTokenType_SetsThemOnAssertion()
+    {
+        var assertion = await CaptureAssertion(
+            audience: Issuer, tokenType: "client-authentication+jwt");
+
+        assertion.Audiences.Should().ContainSingle().Which.Should().Be(Issuer);
+        assertion.Header["typ"].Should().Be("client-authentication+jwt");
+        assertion.Issuer.Should().Be("test-client");
+        assertion.Subject.Should().Be("test-client");
+    }
+
+    [Fact]
+    public async Task GetClientAccessToken_WithoutAudience_UsesTokenEndpointAndPlainJwtType()
+    {
+        var assertion = await CaptureAssertion(audience: null, tokenType: null);
+
+        assertion.Audiences.Should().ContainSingle().Which.Should().Be(TokenEndpoint);
+        assertion.Header["typ"].Should().Be("JWT");
+    }
+
+    private async Task<JwtSecurityToken> CaptureAssertion(string audience, string tokenType)
+    {
+        string capturedAssertion = null;
+        _messageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedAssertion = HttpUtility.ParseQueryString(
+                    req.Content.ReadAsStringAsync().GetAwaiter().GetResult())["client_assertion"])
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("""{ "access_token": "token" }"""),
+            });
+
+        using var httpClient = new HttpClient(_messageHandlerMock.Object);
+        await httpClient.GetClientAccessToken(
+            _tokenUrl, "test-client", _rsaParameters, audience: audience, tokenType: tokenType);
+
+        return new JwtSecurityTokenHandler().ReadJwtToken(capturedAssertion);
     }
 
     private void ArrangeResponse(HttpStatusCode statusCode, string response)

--- a/test/Eryph.IdentityModel.Tests/HttpClientExtensionsTests.cs
+++ b/test/Eryph.IdentityModel.Tests/HttpClientExtensionsTests.cs
@@ -157,7 +157,7 @@ public class HttpClientExtensionsTests
 
         using var httpClient = new HttpClient(_messageHandlerMock.Object);
         await httpClient.GetClientAccessToken(
-            _tokenUrl, "test-client", _rsaParameters, audience: audience, tokenType: tokenType);
+            _tokenUrl, "test-client", _rsaParameters, scopes: null, audience: audience, tokenType: tokenType);
 
         return new JwtSecurityTokenHandler().ReadJwtToken(capturedAssertion);
     }


### PR DESCRIPTION
The eryph identity server is moving to OpenIddict 7.0, which requires the issuer as the client-assertion audience and the new `client-authentication+jwt` token type (the old `token_endpoint` audience is rejected). To keep a single client library working against both old and new eryph servers, the assertion format is now negotiated from the server's discovery document.

- `ClientCredentials` reads the OpenID Connect discovery document from the identity provider and detects the custom metadata flag `eryph_client_assertion_audience`: when present (`issuer`) it uses the issuer as the audience and the `client-authentication+jwt` type; otherwise it falls back to the token-endpoint audience (older servers). Every eryph server serves discovery, so a failure to read it surfaces as an `AccessTokenException` rather than silently downgrading to a format the server would reject.
- `GetClientAccessToken` stays a single-request primitive and gains optional `audience`/`tokenType` parameters so the caller can pass the negotiated values.
- Adds `Microsoft.IdentityModel.Protocols.OpenIdConnect` `8.2.0`, matching the IdentityModel version already used in the repo (the whole `Microsoft.IdentityModel.*` / `System.IdentityModel.Tokens.Jwt` stack resolves uniformly to 8.2.0, with no advisory warnings).
- Adds tests for the new-server, legacy-server and discovery-failure paths (both the `GetClientAccessToken` primitive and the `ClientCredentials` end-to-end path).

The private key is also pinned in unmanaged memory only briefly (around reading the RSA parameters), not across the discovery call.