### PR TITLE
Fix v0.7.0 release build: align JetBrains.Annotations to 2025.2.4

### DIFF
--- a/src/Eryph.IdentityModel.Clients/Eryph.IdentityModel.Clients.csproj
+++ b/src/Eryph.IdentityModel.Clients/Eryph.IdentityModel.Clients.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />


### PR DESCRIPTION
The `v0.7.0` release build failed at `dotnet restore` with NU1605 (warning-as-error):

```
Detected package downgrade: JetBrains.Annotations from 2025.2.4 to 2024.3.0
  Eryph.IdentityModel.Clients -> Eryph.IdentityModel -> JetBrains.Annotations (>= 2025.2.4)
  Eryph.IdentityModel.Clients -> JetBrains.Annotations (>= 2024.3.0)
```

Dependabot #43 bumped JetBrains.Annotations to 2025.2.4 in `Eryph.IdentityModel` but left `Eryph.IdentityModel.Clients` pinned at 2024.3.0, producing a downgrade against the transitively-required version. This aligns the Clients project to 2025.2.4. Verified with `dotnet build -warnaserror` (clean).